### PR TITLE
tweaks.no_sneak_bypass

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -649,6 +649,13 @@ tweaks.feather_falling_no_trample
 	desc:
 		Farmland will not get trampled when wearing feather falling.
 
+tweaks.no_sneak_bypass
+	name: No Sneak bypass
+	since: 1.3.1
+	sides: server_only
+	desc:
+		Blocks which would normally not affect players when sneaking will.
+
 minor_mechanics
 	name: Minor Mechanics
 	since: 1.0

--- a/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/no_sneak_bypass/MixinEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/no_sneak_bypass/MixinEntity.java
@@ -1,0 +1,22 @@
+package com.unascribed.fabrication.mixin.c_tweaks.no_sneak_bypass;
+
+import com.unascribed.fabrication.support.EligibleIf;
+import com.unascribed.fabrication.support.MixinConfigPlugin;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Entity.class)
+@EligibleIf(configEnabled="*.no_sneak_bypass")
+public class MixinEntity {
+	
+	@Inject(at=@At("INVOKE"), method="bypassesSteppingEffects()Z", cancellable=true)
+	public void bypassesSteppingEffects(CallbackInfoReturnable<Boolean> cir) {
+		if (MixinConfigPlugin.isEnabled("*.no_sneak_bypass")) {
+			cir.setReturnValue(false);
+			cir.cancel();
+		}
+	}
+}


### PR DESCRIPTION
unsure if a block besides magma is affected.
but the same reasoning probably applies.