### PR TITLE
Dirt title screen, old tooltip

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -1492,6 +1492,20 @@ woina.no_sprint
 	desc:
 		Disable sprinting.
 
+woina.dirt_screen
+	name: Dirt Screen
+	since: 1.3.5
+	sides: client_only
+	desc:
+		Replaces the panorama background of the title screen with the old dirt one.
+
+woina.old_tooltip
+	name: Old tooltip
+	since: 1.3.5
+	sides: client_only
+	desc:
+		Ressurects the old inventory tooltip from the beta days.
+
 pedantry
 	name: Pedantry
 	since: 1.0.1

--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
-@EligibleIf(configEnabled="*.dirt_screen", envMatches=Env.CLIENT)
+@EligibleIf(envMatches=Env.CLIENT)
 public class MixinTitleScreen extends Screen {
 
     protected MixinTitleScreen(Text title) {

--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
@@ -8,7 +8,12 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -22,11 +27,21 @@ public class MixinTitleScreen extends Screen {
         super(title);
     }
 
-    // @Inject(at=@At(value="INVOKE", target="Lnet/minecraft/client/texture/TextureManager;bindTexture(Lnet/minecraft/util/Identifier;)V"), method="render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V")
+    @Shadow
+    @Final
+    boolean doBackgroundFade;
+
+    @Shadow
+    long backgroundFadeStart;
+
     @Redirect(method = "render", at = @At(value="INVOKE", target="Lnet/minecraft/client/gui/RotatingCubeMapRenderer;render(FF)V"))
     public void drawDirt(RotatingCubeMapRenderer rotatingCubeMapRenderer, float delta, float alpha) {
         if (MixinConfigPlugin.isEnabled("*.dirt_screen")) {
             renderBackgroundTexture(0);
+        }
+        else {
+            float f = doBackgroundFade ? (float)(Util.getMeasuringTimeMs() - backgroundFadeStart) / 1000.0F : 1.0F;
+            rotatingCubeMapRenderer.render(delta, MathHelper.clamp(f,0.0F, 1.0F));
         }
     }
 }

--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
@@ -1,0 +1,29 @@
+package com.unascribed.fabrication.mixin.i_woina.dirt_screen;
+
+import com.unascribed.fabrication.support.EligibleIf;
+import com.unascribed.fabrication.support.Env;
+import com.unascribed.fabrication.support.MixinConfigPlugin;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TitleScreen.class)
+@EligibleIf(configEnabled="*.dirt_screen", envMatches=Env.CLIENT)
+public class MixinTitleScreen extends Screen {
+
+    protected MixinTitleScreen(Text title) {
+        super(title);
+    }
+
+    @Inject(at=@At(value="INVOKE", target="Lnet/minecraft/util/math/MathHelper;ceil(F)I"), method="render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V")
+    public void drawDirt(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (MixinConfigPlugin.isEnabled("*.dirt_screen")) {
+            renderBackgroundTexture(0);
+        }
+    }
+}

--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/dirt_screen/MixinTitleScreen.java
@@ -3,6 +3,7 @@ package com.unascribed.fabrication.mixin.i_woina.dirt_screen;
 import com.unascribed.fabrication.support.EligibleIf;
 import com.unascribed.fabrication.support.Env;
 import com.unascribed.fabrication.support.MixinConfigPlugin;
+import net.minecraft.client.gui.RotatingCubeMapRenderer;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.util.math.MatrixStack;
@@ -10,6 +11,7 @@ import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
@@ -20,8 +22,9 @@ public class MixinTitleScreen extends Screen {
         super(title);
     }
 
-    @Inject(at=@At(value="INVOKE", target="Lnet/minecraft/util/math/MathHelper;ceil(F)I"), method="render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V")
-    public void drawDirt(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    // @Inject(at=@At(value="INVOKE", target="Lnet/minecraft/client/texture/TextureManager;bindTexture(Lnet/minecraft/util/Identifier;)V"), method="render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V")
+    @Redirect(method = "render", at = @At(value="INVOKE", target="Lnet/minecraft/client/gui/RotatingCubeMapRenderer;render(FF)V"))
+    public void drawDirt(RotatingCubeMapRenderer rotatingCubeMapRenderer, float delta, float alpha) {
         if (MixinConfigPlugin.isEnabled("*.dirt_screen")) {
             renderBackgroundTexture(0);
         }

--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/old_tooltip/MixinScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/old_tooltip/MixinScreen.java
@@ -1,0 +1,84 @@
+package com.unascribed.fabrication.mixin.i_woina.old_tooltip;
+
+import com.unascribed.fabrication.support.EligibleIf;
+import com.unascribed.fabrication.support.Env;
+import com.unascribed.fabrication.support.MixinConfigPlugin;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.AbstractParentElement;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TickableElement;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.OrderedText;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Mixin(Screen.class)
+@EligibleIf(configEnabled="*.old_tooltip", envMatches=Env.CLIENT)
+public abstract class MixinScreen extends AbstractParentElement implements TickableElement, Drawable {
+
+    @Shadow
+    public int width;
+
+    @Shadow
+    public int height;
+
+    @Shadow @Nullable protected MinecraftClient client;
+
+    @Inject(method = "renderOrderedTooltip", at = @At(value = "HEAD"), cancellable = true)
+    private void drawOldTooltip(MatrixStack matrices, List<? extends OrderedText> lines, int x, int y, CallbackInfo ci) {
+        if (MixinConfigPlugin.isEnabled("*.old_tooltip")) {
+            // Ported from MCP beta 1.7.3
+            // Slightly altered in order to get item attributes to properly list in the tooltip
+            if (!lines.isEmpty()) {
+                int i = 0;
+                Iterator iter = lines.iterator();
+
+                while (iter.hasNext()) {
+                    OrderedText orderedText = (OrderedText) iter.next();
+                    int j = client.textRenderer.getWidth(orderedText);
+                    if (j > i) {
+                        i = j;
+                    }
+                }
+
+                int k = x + 12;
+                int l = y - 12;
+                int n = 8;
+                if (lines.size() > 1) {
+                    n += 2 + (lines.size() - 1) * 10;
+                }
+
+                if (k + i > this.width) {
+                    k -= 28 + i;
+                }
+
+                if (l + n + 6 > this.height) {
+                    l = this.height - n - 6;
+                }
+                matrices.translate(0.0D, 0.0D, 400.0D);
+                this.fillGradient(matrices, k - 3, l - 3, k + i + 3, l + (11 * lines.size()), -1073741824, -1073741824);
+                for (int s = 0; s < lines.size(); ++s) {
+                    OrderedText orderedText2 = (OrderedText) lines.get(s);
+                    if (orderedText2 != null) {
+                        client.textRenderer.drawWithShadow(matrices, (OrderedText) orderedText2, (float) k, (float) l, -1);
+                    }
+
+                    if (s == 0) {
+                        l += 2;
+                    }
+
+                    l += 10;
+                }
+                ci.cancel();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the old dirt title screen as well as the old item tooltip, both from before beta 1.8.1.
Not specifically requested by anyone but I thought it would be a fitting feature. 
[Dirt title screen](https://i.imgur.com/Y5ehqRa.png)
[Old tooltip](https://i.imgur.com/qkF3Oa5.png)