### PR TITLE
Add null check to MixinEntityType

### DIFF
--- a/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/cracking_spawn_eggs/MixinEntityType.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/cracking_spawn_eggs/MixinEntityType.java
@@ -27,7 +27,7 @@ public class MixinEntityType {
 
 	@Inject(at=@At("RETURN"), method="spawnFromItemStack(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/SpawnReason;ZZ)Lnet/minecraft/entity/Entity;")
 	public void spawnFromItemStack(ServerWorld world, ItemStack stack, PlayerEntity player, BlockPos pos, SpawnReason reason, boolean alignPosition, boolean invertY, CallbackInfoReturnable<Entity> ci) {
-		if (!MixinConfigPlugin.isEnabled("*.cracking_spawn_eggs")) return;
+		if (!MixinConfigPlugin.isEnabled("*.cracking_spawn_eggs") || stack == null) return;
 		if (stack.getItem() instanceof SpawnEggItem) {
 			Entity e = ci.getReturnValue();
 			Box box = e.getBoundingBox();


### PR DESCRIPTION
Not all calls to EntityType#spawnFromItemStack actually pass an ItemStack argument. Omni (Forge mod) calls the method with a null ItemStack argument, resulting in a crash when used alongside Forgery's cracking_spawn_eggs module. See https://github.com/AeiouEnigma/lithium-forge/issues/2 for further details.

This should prevent similar NullPointerExceptions from occurring.