### PR TITLE
BlockLogo: allow using any BlockState, custom shadow color

### DIFF
--- a/src/main/java/com/unascribed/fabrication/mixin/i_woina/block_logo/MixinTitleScreen.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/i_woina/block_logo/MixinTitleScreen.java
@@ -295,7 +295,9 @@ public class MixinTitleScreen extends Screen {
 						mc.getTextureManager().bindTexture(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE);
 						Tessellator.getInstance().draw();
 					} else {
-						GlStateManager.color4f(0, 0, 0, 0.855f*alpha*fade);
+						GlStateManager.color4f(
+								LoaderBlockLogo.shadowRed, LoaderBlockLogo.shadowGreen, LoaderBlockLogo.shadowBlue,
+								LoaderBlockLogo.shadowAlpha*alpha*fade);
 						BufferBuilder bb = Tessellator.getInstance().getBuffer();
 						bb.begin(GL11.GL_QUADS, VertexFormats.POSITION);
 						bb.vertex(0, 0, 0).next();

--- a/src/main/resources/default_block_logo_config.ini
+++ b/src/main/resources/default_block_logo_config.ini
@@ -7,6 +7,14 @@ reverse=false
 ; Play block placement sounds as the blocks land.
 sound=false
 
+[shadow]
+; What color the shadow under the blocks should be.
+; Range 0-255 for each component.
+red=0
+green=0
+blue=0
+alpha=225
+
 ; You can map pixel colors to blocks here. Syntax is straightforward; key
 ; is a 24-bit hex color, value is the identifier of the block to render. You
 ; may specify multiple identifiers separated by spaces, in which case a random


### PR DESCRIPTION
In the current implementation the menu BlockLogo only allows using
default block states as it only parses the block name. This commit
replaces this parsing with the one used by console commands, which
includes blockstate parsing, so you can now do stuff like
`000000=minecraft:redstone_lamp[lit=true]`.

Also introduces a [shadow] INI segment to allow customisation of the
shadow color & alpha value.