### PR TITLE
Fix Endermen Don't Grief

### DIFF
--- a/src/main/java/com/unascribed/fabrication/mixin/g_weird_tweaks/endermen_dont_grief/MixinEndermanEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/g_weird_tweaks/endermen_dont_grief/MixinEndermanEntity.java
@@ -2,17 +2,18 @@ package com.unascribed.fabrication.mixin.g_weird_tweaks.endermen_dont_grief;
 
 import com.unascribed.fabrication.support.EligibleIf;
 import com.unascribed.fabrication.support.MixinConfigPlugin;
-import net.minecraft.world.GameRules;
-import net.minecraft.world.GameRules.Key;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(targets = {"net.minecraft.entity.mob.EndermanEntity$PickUpBlockGoal","net.minecraft.entity.mob.EndermanEntity$PlaceBlockGoal"})
 @EligibleIf(configAvailable="*.endermen_dont_grief")
 public class MixinEndermanEntity {
-	@Redirect(method = "canStart()Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-	private boolean canStart(GameRules gameRules, Key<GameRules.BooleanRule> rule) {
-		return !MixinConfigPlugin.isEnabled("*.endermen_dont_grief");
+	@Inject(method = "canStart()Z", at = @At("HEAD"), cancellable = true)
+	private void canStart(CallbackInfoReturnable<Boolean> info) {
+		if (MixinConfigPlugin.isEnabled("*.endermen_dont_grief")) {
+			info.setReturnValue(false);
+		}
 	}
 }


### PR DESCRIPTION
Removes a redirect and replaces it with a head injection so that it's mildly safer and also works on forge (where the target has been patched out by the api).
Also fixes a bug where this feature could override mobGriefing behavior.