### PR TITLE
add "no heavy minecarts" feature

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -881,11 +881,11 @@ tweaks.recipe_book_auto_craft
 		Recipe book crafts items instead of moving them to the crafting area.
 
 tweaks.no_heavy_minecarts
-    name: No Heavy Minecarts
-    since: 2.1.0
-    sides: server_only
-    desc:
-        Chest and hopper minecarts will not be slowed down proportionally to the number of items in them.
+	name: No Heavy Minecarts
+	since: 2.1.0
+	sides: server_only
+	desc:
+		Chest and hopper minecarts will not be slowed down proportionally to the number of items in them.
 
 
 minor_mechanics

--- a/features.txt
+++ b/features.txt
@@ -880,6 +880,13 @@ tweaks.recipe_book_auto_craft
 	desc:
 		Recipe book crafts items instead of moving them to the crafting area.
 
+tweaks.no_heavy_minecarts
+    name: No Heavy Minecarts
+    since: 2.1.0
+    sides: server_only
+    desc:
+        Chest and hopper minecarts will not be slowed down proportionally to the number of items in them.
+
 
 minor_mechanics
 	name: Minor Mechanics

--- a/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/no_heavy_minecarts/MixinStorageMinecartEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/c_tweaks/no_heavy_minecarts/MixinStorageMinecartEntity.java
@@ -1,0 +1,35 @@
+package com.unascribed.fabrication.mixin.c_tweaks.no_heavy_minecarts;
+
+import com.unascribed.fabrication.support.EligibleIf;
+import com.unascribed.fabrication.support.MixinConfigPlugin;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.entity.vehicle.StorageMinecartEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(StorageMinecartEntity.class)
+@EligibleIf(configAvailable="*.no_heavy_minecarts")
+public abstract class MixinStorageMinecartEntity extends AbstractMinecartEntity {
+	protected MixinStorageMinecartEntity(EntityType<?> entityType, World world) {
+		super(entityType, world);
+	}
+
+	@Inject(method="applySlowdown", at=@At("HEAD"))
+	private void cancelSlowdown(CallbackInfo ci) {
+		if (MixinConfigPlugin.isEnabled("*.no_heavy_minecarts")) {
+			//has to reimplement since mixin cant affect flow control well and it would need a redirect otherwise
+			float slowdown = 0.98F;
+
+			if (this.isTouchingWater()) {
+				slowdown *= 0.95F;
+			}
+
+			this.setVelocity(this.getVelocity().multiply(slowdown, 0.0D, slowdown));
+			ci.cancel();
+		}
+	}
+}


### PR DESCRIPTION
i found out today that chest and hopper minecarts slow down when you put a lot of stuff in them and decided unilaterally that that sucks

enabling `tweaks.no_heavy_minecarts` will make it so chest/hopper carts will only slow down due to natural friction from the fluid theyre moving through (either air or water)

should be everything necessary to add a feature but please let me know if somethings missing