### PR TITLE
add minor_mechanics.water_fills_on_break_strict

### DIFF
--- a/features.d/water.yml
+++ b/features.d/water.yml
@@ -1,0 +1,7 @@
+minor_mechanics.water_fills_on_break_strict:
+	name: Water Fills On Break Strict
+	since: 2.3.1
+	sides: server_only
+	extend: *.water_fills_on_break
+	desc:
+		Requires water_fills_on_break to have at least 2 water sources.

--- a/src/main/java/com/unascribed/fabrication/logic/WaterFillsOnBreak.java
+++ b/src/main/java/com/unascribed/fabrication/logic/WaterFillsOnBreak.java
@@ -2,6 +2,7 @@ package com.unascribed.fabrication.logic;
 
 import com.google.common.collect.ImmutableSet;
 
+import com.unascribed.fabrication.support.MixinConfigPlugin;
 import net.minecraft.block.BlockState;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.tag.FluidTags;
@@ -18,11 +19,13 @@ public class WaterFillsOnBreak {
 	public static boolean shouldFill(World world, BlockPos pos) {
 		int countWater = 0;
 		int countAir = 0;
+		BlockPos lastWater = null;
 		for (Direction d : CHECK_DIRECTIONS) {
 			BlockPos p = pos.offset(d);
 			FluidState fluid = world.getFluidState(p);
 
 			if (fluid.isIn(FluidTags.WATER) && fluid.isStill()) {
+				lastWater = p;
 				countWater++;
 			} else if (d != Direction.UP) {
 				BlockState bs = world.getBlockState(p);
@@ -31,7 +34,18 @@ public class WaterFillsOnBreak {
 				}
 			}
 		}
-		return countWater > countAir;
+		if (!(MixinConfigPlugin.isEnabled("*.water_fills_on_break_strict") && countWater == 1)){
+			return countWater > countAir;
+		}
+
+		for (Direction d : Direction.values()) {
+			FluidState fluid = world.getFluidState(lastWater.offset(d));
+
+			if (fluid.isIn(FluidTags.WATER) && fluid.isStill()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/water_fills_on_break/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/water_fills_on_break/MixinServerPlayerInteractionManager.java
@@ -17,7 +17,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 
 @Mixin(ServerPlayerInteractionManager.class)
-@EligibleIf(configAvailable="*.water_fills_on_break", specialConditions=SpecialEligibility.FORGE)
+@EligibleIf(anyConfigAvailable={"*.water_fills_on_break", "*.water_fills_on_break_strict"}, specialConditions=SpecialEligibility.FORGE)
 public class MixinServerPlayerInteractionManager {
 
 	@Shadow
@@ -28,7 +28,7 @@ public class MixinServerPlayerInteractionManager {
 
 	@Inject(at=@At("RETURN"), method="tryBreakBlock(Lnet/minecraft/util/math/BlockPos;)Z", cancellable=true)
 	public void tryBreakBlock(BlockPos pos, CallbackInfoReturnable<Boolean> ci) {
-		if (MixinConfigPlugin.isEnabled("*.water_fills_on_break") && ci.getReturnValueZ()) {
+		if (MixinConfigPlugin.isAnyEnabled("*.water_fills_on_break") && ci.getReturnValueZ()) {
 			if (WaterFillsOnBreak.shouldFill(world, pos) && world.getBlockState(pos).isAir()) {
 				world.setBlockState(pos, Fluids.WATER.getDefaultState().getBlockState());
 			}

--- a/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/water_fills_on_break/MixinWorld.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/water_fills_on_break/MixinWorld.java
@@ -16,12 +16,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 @Mixin(World.class)
-@EligibleIf(configAvailable="*.water_fills_on_break")
+@EligibleIf(anyConfigAvailable={"*.water_fills_on_break", "*.water_fills_on_break_strict"})
 public class MixinWorld {
 
 	@Inject(at=@At("HEAD"), method="removeBlock(Lnet/minecraft/util/math/BlockPos;Z)Z", cancellable=true)
 	public void removeBlock(BlockPos pos, boolean move, CallbackInfoReturnable<Boolean> ci) {
-		if (MixinConfigPlugin.isEnabled("*.water_fills_on_break")) {
+		if (MixinConfigPlugin.isAnyEnabled("*.water_fills_on_break")) {
 			World self = (World)(Object)this;
 			if (WaterFillsOnBreak.shouldFill(self, pos)) {
 				ci.setReturnValue(self.setBlockState(pos, Fluids.WATER.getDefaultState().getBlockState(), 3 | (move ? 64 : 0)));
@@ -31,7 +31,7 @@ public class MixinWorld {
 
 	@Inject(at=@At("RETURN"), method="breakBlock(Lnet/minecraft/util/math/BlockPos;ZLnet/minecraft/entity/Entity;I)Z", cancellable=true)
 	public void breakBlock(BlockPos pos, boolean drop, @Nullable Entity breakingEntity, int maxUpdateDepth, CallbackInfoReturnable<Boolean> ci) {
-		if (MixinConfigPlugin.isEnabled("*.water_fills_on_break") && ci.getReturnValueZ()) {
+		if (MixinConfigPlugin.isAnyEnabled("*.water_fills_on_break") && ci.getReturnValueZ()) {
 			World self = (World)(Object)this;
 			if (WaterFillsOnBreak.shouldFill(self, pos)) {
 				ci.setReturnValue(self.setBlockState(pos, Fluids.WATER.getDefaultState().getBlockState(), 3));


### PR DESCRIPTION
unascribed/fabrication-features#107

> in the specific circumstance that there is one water source block and zero air blocks

assuming the `zero air blocks` part was a mistake