### PR TITLE
Update to Minecraft 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.11-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -48,15 +48,17 @@ dependencies {
 	modImplementation include(fabricApi.module("fabric-item-api-v1", "${project.fabric_version}"))
 	modImplementation include(fabricApi.module("fabric-key-binding-api-v1", "${project.fabric_version}"))
 	modImplementation include(fabricApi.module("fabric-rendering-v1", "${project.fabric_version}"))
+	// Required since 1.18.2 due to Fabric not doing things the right way
+	modImplementation include(fabricApi.module("fabric-registry-sync-v0", "${project.fabric_version}"))
 	
 	modImplementation(include("io.github.queerbric:pridelib:1.1.0+1.17")) {
 		transitive = false
 	}
-	modImplementation("com.terraformersmc:modmenu:2.0.3") {
+	modImplementation("com.terraformersmc:modmenu:3.1.0") {
 		transitive = false
 	}
-	modImplementation "com.unascribed:ears-api:1.4.1"
-	modImplementation("tf.ssf.sfort:fscript:1.1.5") {
+	modImplementation "com.unascribed:ears-api:1.4.5"
+	modImplementation("tf.ssf.sfort:fscript:2.2.0") {
 		transitive = false
 	}
 	modRuntimeOnly fabricApi.module("fabric-screen-api-v1", "${project.fabric_version}")

--- a/features.d/e_tweaks.yml
+++ b/features.d/e_tweaks.yml
@@ -237,6 +237,8 @@ tweaks.no_dinnerlava:
 		in a short span of time in the 1.5 era mostly on provocation from Vechs of Super Hostile
 		fame.
 
+		Will not take effect unless the world is reloaded.
+
 tweaks.silent_minecarts:
 	name: Silent Minecarts
 	since: 1.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18.1
-	yarn_mappings=1.18.1+build.7
-	loader_version=0.12.12
-	fabric_version=0.44.0+1.18
+	minecraft_version=1.18.2
+	yarn_mappings=1.18.2+build.2
+	loader_version=0.13.3
+	fabric_version=0.48.0+1.18.2
 
 # Mod Properties
 	maven_group = com.unascribed

--- a/src/main/java/com/unascribed/fabrication/FabricationModClient.java
+++ b/src/main/java/com/unascribed/fabrication/FabricationModClient.java
@@ -11,7 +11,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v1.ClientCommandManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.resource.ReloadableResourceManager;
+import net.minecraft.resource.ReloadableResourceManagerImpl;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceReloader;
 import net.minecraft.util.Unit;
@@ -24,7 +24,7 @@ public class FabricationModClient implements ClientModInitializer {
 
 		if (!MixinConfigPlugin.isBanned("*.classic_block_drops")) {
 			MinecraftClient.getInstance().send(() -> {
-				((ReloadableResourceManager)MinecraftClient.getInstance().getResourceManager()).registerReloader(new ResourceReloader() {
+				((ReloadableResourceManagerImpl)MinecraftClient.getInstance().getResourceManager()).registerReloader(new ResourceReloader() {
 					@Override
 					public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
 						return synchronizer.whenPrepared(Unit.INSTANCE).thenRunAsync(() -> {

--- a/src/main/java/com/unascribed/fabrication/client/FScriptScreen.java
+++ b/src/main/java/com/unascribed/fabrication/client/FScriptScreen.java
@@ -165,7 +165,7 @@ public class FScriptScreen extends ScriptingScreen {
 					fill(matrices, 0, (int) y+11, textRenderer.getWidth(feature.name)+16, (int) y+12, -1);
 					if (didClick){
 						out.accept(feature.fscriptDefault);
-						onClose();
+						close();
 					}
 				}
 				sidebarHeight+=20;
@@ -189,7 +189,7 @@ public class FScriptScreen extends ScriptingScreen {
 			return super.mouseScrolled(mouseX, mouseY, amount);
 		}
 		@Override
-		public void onClose() {
+		public void close() {
 			client.setScreen(parent);
 		}
 		@Override

--- a/src/main/java/com/unascribed/fabrication/client/FabricationConfigScreen.java
+++ b/src/main/java/com/unascribed/fabrication/client/FabricationConfigScreen.java
@@ -657,7 +657,7 @@ public class FabricationConfigScreen extends Screen {
 		}
 
 		if (drawButton(matrices, width-100, height-20, 100, 20, "Done", mouseX, mouseY)) {
-			onClose();
+			close();
 		}
 		if (didClick) didClick = false;
 
@@ -1193,7 +1193,7 @@ public class FabricationConfigScreen extends Screen {
 	}
 
 	@Override
-	public void onClose() {
+	public void close() {
 		if (!MixinConfigPlugin.isEnabled("*.reduced_motion") && !leaving) {
 			leaving = true;
 			client.getSoundManager().play(PositionedSoundInstance.master(SoundEvents.BLOCK_BARREL_CLOSE, 0.7f));

--- a/src/main/java/com/unascribed/fabrication/features/FeatureFabricationCommand.java
+++ b/src/main/java/com/unascribed/fabrication/features/FeatureFabricationCommand.java
@@ -139,7 +139,7 @@ public class FeatureFabricationCommand implements Feature {
 					LiteralArgumentBuilder<ServerCommandSource> biome = CommandManager.literal("biome");
 
 
-					for (Map.Entry<RegistryKey<Biome>, Biome> en : BuiltinRegistries.BIOME.getEntries()) {
+					for (Map.Entry<RegistryKey<Biome>, Biome> en : BuiltinRegistries.BIOME.getEntrySet()) {
 						Identifier id = en.getKey().getValue();
 						Identifier b = en.getKey().getValue();
 						Command<ServerCommandSource> exec = c -> {
@@ -230,7 +230,7 @@ public class FeatureFabricationCommand implements Feature {
 								for (int cZ = 0; cZ < 16; cZ++) {
 									if (biomes != null) {
 										ChunkGenerator generator = ((ServerWorld)world).getChunkManager().getChunkGenerator();
-										Biome b = generator.getBiomeSource().getBiome(cX+chunk.getPos().getStartX(), cY, cZ+chunk.getPos().getStartZ(), generator.getMultiNoiseSampler());
+										Biome b = generator.getBiomeSource().getBiome(cX+chunk.getPos().getStartX(), cY, cZ+chunk.getPos().getStartZ(), generator.getMultiNoiseSampler()).value();
 										if (!biomes.contains(b)) {
 											skipped++;
 											if (skipped > goal && scanned == 0) {

--- a/src/main/java/com/unascribed/fabrication/features/FeatureNoDinnerlava.java
+++ b/src/main/java/com/unascribed/fabrication/features/FeatureNoDinnerlava.java
@@ -1,30 +1,27 @@
 package com.unascribed.fabrication.features;
 
-import java.util.Set;
-
 import com.unascribed.fabrication.support.EligibleIf;
 import com.unascribed.fabrication.support.Feature;
 
-import com.google.common.collect.ImmutableSet;
-
 import net.minecraft.block.Block;
+import net.minecraft.util.registry.RegistryEntryList;
 import net.minecraft.world.gen.feature.NetherConfiguredFeatures;
 
 @EligibleIf(configAvailable="*.no_dinnerlava")
 public class FeatureNoDinnerlava implements Feature {
 
-	private Set<Block> originalValidBlocks;
+	private RegistryEntryList<Block> originalValidBlocks;
 
 	@Override
 	public void apply() {
-		originalValidBlocks = NetherConfiguredFeatures.SPRING_NETHER_CLOSED.config.validBlocks;
-		NetherConfiguredFeatures.SPRING_NETHER_CLOSED.config.validBlocks = ImmutableSet.of();
+		originalValidBlocks = NetherConfiguredFeatures.SPRING_NETHER_CLOSED.value().config().validBlocks;
+		NetherConfiguredFeatures.SPRING_NETHER_CLOSED.value().config().validBlocks = RegistryEntryList.of();
 	}
 
 	@Override
 	public boolean undo() {
 		if (originalValidBlocks != null) {
-			NetherConfiguredFeatures.SPRING_NETHER_CLOSED.config.validBlocks = originalValidBlocks;
+			NetherConfiguredFeatures.SPRING_NETHER_CLOSED.value().config().validBlocks = originalValidBlocks;
 			originalValidBlocks = null;
 		}
 		return true;

--- a/src/main/java/com/unascribed/fabrication/loaders/LoaderDimensionalTools.java
+++ b/src/main/java/com/unascribed/fabrication/loaders/LoaderDimensionalTools.java
@@ -33,13 +33,12 @@ import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtList;
-import net.minecraft.tag.BlockTags;
-import net.minecraft.tag.ItemTags;
-import net.minecraft.tag.Tag;
-import net.minecraft.tag.TagGroup;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.dimension.DimensionType;
 
 public class LoaderDimensionalTools implements ConfigLoader {
@@ -181,7 +180,7 @@ public class LoaderDimensionalTools implements ConfigLoader {
 	}
 
 	public static Set<MohsIdentifier> getAssociatedDimensionsForTool(ItemStack stack) {
-		Set<MohsIdentifier> dims = processTags(toolAssociations.get(Registry.ITEM.getId(stack.getItem())), toolTagAssociations, ItemTags.getTagGroup(), stack.getItem());
+		Set<MohsIdentifier> dims = processTags(toolAssociations.get(Registry.ITEM.getId(stack.getItem())), toolTagAssociations, Registry.ITEM_KEY, stack.getItem().getRegistryEntry());
 		if (stack.hasNbt()) {
 			if (stack.getNbt().getBoolean("fabrication:ActLikeGold")) {
 				dims = Sets.newHashSet(dims);
@@ -203,18 +202,18 @@ public class LoaderDimensionalTools implements ConfigLoader {
 	}
 
 	public static Set<MohsIdentifier> getAssociatedDimensionsForIngredient(ItemStack stack) {
-		return processTags(ingredientAssociations.get(Registry.ITEM.getId(stack.getItem())), ingredientTagAssociations, ItemTags.getTagGroup(), stack.getItem());
+		return processTags(ingredientAssociations.get(Registry.ITEM.getId(stack.getItem())), ingredientTagAssociations, Registry.ITEM_KEY, stack.getItem().getRegistryEntry());
 	}
 
 	public static Set<MohsIdentifier> getAssociatedDimensions(Block block) {
-		return processTags(blockAssociations.get(Registry.BLOCK.getId(block)), blockTagAssociations, BlockTags.getTagGroup(), block);
+		return processTags(blockAssociations.get(Registry.BLOCK.getId(block)), blockTagAssociations, Registry.BLOCK_KEY, block.getRegistryEntry());
 	}
 
-	private static <T, U> Set<U> processTags(Set<U> out, SetMultimap<Identifier, U> assoc, TagGroup<T> tagGroup, T entry) {
+	private static <T, U> Set<U> processTags(Set<U> out, SetMultimap<Identifier, U> assoc, RegistryKey<? extends Registry<T>> key, RegistryEntry<T> entry) {
 		boolean cloned = false;
 		for (Map.Entry<Identifier, U> en : assoc.entries()) {
-			Tag<T> tag = tagGroup.getTag(en.getKey());
-			if (tag != null && tag.contains(entry)) {
+			TagKey<T> tag = TagKey.of(key, en.getKey());
+			if (entry.isIn(tag)) {
 				if (!cloned) {
 					out = Sets.newHashSet(out);
 					cloned = true;
@@ -228,8 +227,8 @@ public class LoaderDimensionalTools implements ConfigLoader {
 	public static boolean isSubstitutable(Item item) {
 		if (substitutableItems.contains(Registry.ITEM.getId(item))) return true;
 		for (Identifier id : substitutableItemTags) {
-			Tag<Item> tag = ItemTags.getTagGroup().getTag(id);
-			if (tag != null && tag.contains(item)) return true;
+			TagKey<Item> tag = TagKey.of(Registry.ITEM_KEY, id);
+			if (item.getRegistryEntry().isIn(tag)) return true;
 		}
 		return false;
 	}

--- a/src/main/java/com/unascribed/fabrication/loaders/LoaderGearComponents.java
+++ b/src/main/java/com/unascribed/fabrication/loaders/LoaderGearComponents.java
@@ -24,9 +24,7 @@ import com.google.common.primitives.Ints;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
-import net.minecraft.tag.BlockTags;
-import net.minecraft.tag.ItemTags;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
@@ -191,10 +189,10 @@ public class LoaderGearComponents implements ConfigLoader {
 
 	private static Supplier<Item> tagResolver(Identifier id) {
 		return () -> {
-			Tag<Item> itemTag = ItemTags.getTagGroup().getTag(id);
-			if (itemTag != null) return itemTag.getRandom(rand);
-			Tag<Block> blockTag = BlockTags.getTagGroup().getTag(id);
-			if (blockTag != null) return blockTag.getRandom(rand).asItem();
+			TagKey<Item> itemTag = TagKey.of(Registry.ITEM_KEY, id);
+			if (Registry.ITEM.containsTag(itemTag)) return Registry.ITEM.getEntryList(itemTag).flatMap(items -> items.getRandom(rand)).map(itemEntry -> itemEntry.value()).orElse(null);
+			TagKey<Block> blockTag = TagKey.of(Registry.BLOCK_KEY, id);
+			if (Registry.BLOCK.containsTag(blockTag)) return Registry.BLOCK.getEntryList(blockTag).flatMap(blocks -> blocks.getRandom(rand)).map(blockEntry -> blockEntry.value().asItem()).orElse(null);
 			return null;
 		};
 	}

--- a/src/main/java/com/unascribed/fabrication/mixin/a_fixes/adventure_tags_in_survival/MixinItemStack.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/a_fixes/adventure_tags_in_survival/MixinItemStack.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.registry.Registry;
 
 @Mixin(ItemStack.class)
 @EligibleIf(configAvailable="*.adventure_tags_in_survival")
@@ -27,7 +28,7 @@ public class MixinItemStack {
 		ItemStack self = (ItemStack)(Object)this;
 		if (!self.isEmpty()) {
 			if (self.hasNbt() && self.getNbt().contains("CanPlaceOn")) {
-				boolean able = self.canPlaceOn(iuc.getWorld().getTagManager(), new CachedBlockPosition(iuc.getWorld(), iuc.getBlockPos(), false));
+				boolean able = self.canPlaceOn(iuc.getWorld().getRegistryManager().get(Registry.BLOCK_KEY), new CachedBlockPosition(iuc.getWorld(), iuc.getBlockPos(), false));
 				if (!able) {
 					ci.setReturnValue(ActionResult.PASS);
 				}

--- a/src/main/java/com/unascribed/fabrication/mixin/a_fixes/adventure_tags_in_survival/MixinPlayerEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/a_fixes/adventure_tags_in_survival/MixinPlayerEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 
@@ -39,7 +40,7 @@ public abstract class MixinPlayerEntity extends LivingEntity {
 		ItemStack stack = getMainHandStack();
 		if (!stack.isEmpty()) {
 			if (stack.hasNbt() && stack.getNbt().contains("CanDestroy")) {
-				ci.setReturnValue(!stack.canDestroy(world.getTagManager(), new CachedBlockPosition(world, pos, false)));
+				ci.setReturnValue(!stack.canDestroy(world.getRegistryManager().get(Registry.BLOCK_KEY), new CachedBlockPosition(world, pos, false)));
 			}
 		}
 	}
@@ -52,7 +53,7 @@ public abstract class MixinPlayerEntity extends LivingEntity {
 		if (!MixinConfigPlugin.isEnabled("*.adventure_tags_in_survival") || abilities.creativeMode || !abilities.allowModifyWorld) return;
 		if (!stack.isEmpty()) {
 			if (stack.hasNbt() && stack.getNbt().contains("CanPlaceOn")) {
-				ci.setReturnValue(stack.canPlaceOn(world.getTagManager(), new CachedBlockPosition(world, pos.offset(dir.getOpposite()), false)));
+				ci.setReturnValue(stack.canPlaceOn(world.getRegistryManager().get(Registry.BLOCK_KEY), new CachedBlockPosition(world, pos.offset(dir.getOpposite()), false)));
 			}
 		}
 	}

--- a/src/main/java/com/unascribed/fabrication/mixin/a_fixes/fix_superflat_bad_structures/MixinFlatChunkGeneratorConfig.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/a_fixes/fix_superflat_bad_structures/MixinFlatChunkGeneratorConfig.java
@@ -13,10 +13,10 @@ import com.unascribed.fabrication.support.EligibleIf;
 import com.unascribed.fabrication.support.MixinConfigPlugin;
 
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.GenerationSettings;
 import net.minecraft.world.gen.chunk.FlatChunkGeneratorConfig;
-import net.minecraft.world.gen.feature.ConfiguredStructureFeature;
 
 @Mixin(FlatChunkGeneratorConfig.class)
 @EligibleIf(configAvailable="*.fix_superflat_bad_structures")
@@ -25,9 +25,9 @@ public class MixinFlatChunkGeneratorConfig {
 	@Shadow @Final
 	private Registry<Biome> biomeRegistry;
 
-	@Redirect(at=@At(value="INVOKE", target="net/minecraft/world/biome/GenerationSettings$Builder.feature (Lnet/minecraft/world/gen/GenerationStep$Feature;Lnet/minecraft/world/gen/feature/PlacedFeature;)Lnet/minecraft/world/biome/GenerationSettings$Builder;"),
+	@Redirect(at=@At(value="INVOKE", target="net/minecraft/world/biome/GenerationSettings$Builder.feature (Lnet/minecraft/world/gen/GenerationStep$Feature;Lnet/minecraft/util/registry/RegistryEntry;)Lnet/minecraft/world/biome/GenerationSettings$Builder;"),
 			method="createBiome()Lnet/minecraft/world/biome/Biome;")
-	public GenerationSettings.Builder createBiomeAddStructureFeature(GenerationSettings.Builder subject, GenerationStep.Feature featureStep, PlacedFeature feature) {
+	public GenerationSettings.Builder createBiomeAddStructureFeature(GenerationSettings.Builder subject, GenerationStep.Feature featureStep, RegistryEntry<PlacedFeature> feature) {
 		if (MixinConfigPlugin.isEnabled("*.fix_superflat_bad_structures") && feature == null) {
 			FabLog.debug("Preventing a bad structure from being added to a flat world generator.");
 		} else {

--- a/src/main/java/com/unascribed/fabrication/mixin/b_utility/item_despawn/MixinItemEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/b_utility/item_despawn/MixinItemEntity.java
@@ -36,9 +36,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.packet.s2c.play.EntityPositionS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.tag.BlockTags;
-import net.minecraft.tag.ItemTags;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
@@ -151,8 +149,8 @@ public abstract class MixinItemEntity extends Entity implements SetFromPlayerDea
 				}
 			}
 			for (Map.Entry<Identifier, ParsedTime> en : LoaderItemDespawn.tagDespawns.entrySet()) {
-				Tag<Item> itemTag = ItemTags.getTagGroup().getTag(en.getKey());
-				if (itemTag != null && itemTag.contains(stack.getItem())) {
+				TagKey<Item> itemTag = TagKey.of(Registry.ITEM_KEY, en.getKey());
+				if (stack.isIn(itemTag)) {
 					if (en.getValue().overshadows(time)) {
 						if (debug) System.out.println("Found a tag; it overshadows: "+en.getValue());
 						time = en.getValue();
@@ -160,8 +158,8 @@ public abstract class MixinItemEntity extends Entity implements SetFromPlayerDea
 				}
 				if (stack.getItem() instanceof BlockItem) {
 					BlockItem bi = (BlockItem)stack.getItem();
-					Tag<Block> blockTag = BlockTags.getTagGroup().getTag(en.getKey());
-					if (blockTag != null && blockTag.contains(bi.getBlock())) {
+					TagKey<Block> blockTag = TagKey.of(Registry.BLOCK_KEY, en.getKey());
+					if (bi.getBlock().getRegistryEntry().isIn(blockTag)) {
 						if (en.getValue().overshadows(time)) {
 							if (debug) System.out.println("Found a tag; it overshadows: "+en.getValue());
 							time = en.getValue();

--- a/src/main/java/com/unascribed/fabrication/mixin/b_utility/taggable_players/MixinHungerManager.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/b_utility/taggable_players/MixinHungerManager.java
@@ -20,7 +20,7 @@ import net.minecraft.entity.player.PlayerEntity;
 public abstract class MixinHungerManager implements SetSaturation {
 
 	@Shadow
-	private float foodSaturationLevel;
+	private float saturationLevel;
 
 	@Inject(at=@At("HEAD"), method="update(Lnet/minecraft/entity/player/PlayerEntity;)V", cancellable=true)
 	public void update(PlayerEntity pe, CallbackInfo ci) {
@@ -33,7 +33,7 @@ public abstract class MixinHungerManager implements SetSaturation {
 
 	@Override
 	public void fabrication$setSaturation(float sat) {
-		foodSaturationLevel = sat;
+		saturationLevel = sat;
 	}
 
 }

--- a/src/main/java/com/unascribed/fabrication/mixin/b_utility/taggable_players/MixinPhantomSpawner.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/b_utility/taggable_players/MixinPhantomSpawner.java
@@ -9,7 +9,7 @@ import com.unascribed.fabrication.logic.PlayerTag;
 import com.unascribed.fabrication.support.EligibleIf;
 
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.world.gen.PhantomSpawner;
+import net.minecraft.world.spawner.PhantomSpawner;
 
 @Mixin(PhantomSpawner.class)
 @EligibleIf(configAvailable="*.taggable_players")

--- a/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/collision_based_landing_pos/MixinEntity.java
+++ b/src/main/java/com/unascribed/fabrication/mixin/d_minor_mechanics/collision_based_landing_pos/MixinEntity.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinEntity {
 
 	@Shadow public World world;
-	@Shadow private Box entityBounds;
+	@Shadow private Box boundingBox;
 
 	@Shadow public abstract double getY();
 	@Shadow public abstract double getZ();
@@ -29,7 +29,7 @@ public abstract class MixinEntity {
 	@Inject(method="getLandingPos()Lnet/minecraft/util/math/BlockPos;", at=@At(value="HEAD"), cancellable=true)
 	public void getLandingPos(CallbackInfoReturnable<BlockPos> cir) {
 		if (!MixinConfigPlugin.isEnabled("*.collision_based_landing_pos")) return;
-		for (VoxelShape shape : world.getBlockCollisions((Entity)(Object)this, this.entityBounds.offset(0, -0.20000000298023224D, 0))) {
+		for (VoxelShape shape : world.getBlockCollisions((Entity)(Object)this, this.boundingBox.offset(0, -0.20000000298023224D, 0))) {
 			if (shape.getBoundingBox().getCenter().getY() <= this.getY()) {
 				cir.setReturnValue(new BlockPos(shape.getBoundingBox().getCenter()));
 				return;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,8 @@
     "fabric-resource-loader-v0": "*",
     "fabric-command-api-v1": "*",
     "fabric-key-binding-api-v1": "*",
-    "fabric-rendering-v1": "*"
+    "fabric-rendering-v1": "*",
+    "fabric-registry-sync-v0": "*"
   },
   "suggests": {
   },

--- a/src/main/resources/fabrication.accesswidener
+++ b/src/main/resources/fabrication.accesswidener
@@ -3,7 +3,7 @@ accessWidener v1 named
 mutable field net/minecraft/resource/ResourcePackManager providers Ljava/util/Set;
 
 mutable field net/minecraft/predicate/entity/EntityPredicates EXCEPT_CREATIVE_OR_SPECTATOR Ljava/util/function/Predicate;
-mutable field net/minecraft/world/gen/feature/SpringFeatureConfig validBlocks Ljava/util/Set;
+mutable field net/minecraft/world/gen/feature/SpringFeatureConfig validBlocks Lnet/minecraft/util/registry/RegistryEntryList;
 
 accessible class net/minecraft/server/world/ThreadedAnvilChunkStorage$EntityTracker
 accessible class net/minecraft/client/texture/Sprite$Animation


### PR DESCRIPTION
This updates the mod to Minecraft 1.18.2. The following changes were made:
- Updated all the dependencies to their latest versions
- All the tag-related code was updated in order to use the refactored system
- Due to Fabric shenanigans, which involved not updating the entrypoints on the Loader to happen before the registry freeze and instead unfreezing the registry through the API, the Registry Sync module is now required
- Updated the "No Dinnerlava" module. Unfortunately, due to 1.18.2 changes, it now requires a `/reload` in order to apply the changes (I did sink hours on attempting to fix that though), although on the bright side, it's now super easy to test it with `/placefeature spring_nether_closed ~ ~ ~`