### PR TITLE
Prevent Interactic's "Disable Auto Pickup" feature from interfering with instant pickup

### DIFF
--- a/src/main/java/com/unascribed/fabrication/logic/InstantPickup.java
+++ b/src/main/java/com/unascribed/fabrication/logic/InstantPickup.java
@@ -16,9 +16,11 @@ public class InstantPickup {
 			if (!ie.isAlive()) continue;
 			int oldPickupDelay = FabRefl.getPickupDelay(ie);
 			ie.setPickupDelay(0);
+			ie.getScoreboardTags().add("interactic.ignore_auto_pickup_rule");
 			ie.onPlayerCollision(breaker);
 			if (ie.isAlive()) {
 				ie.setPickupDelay(oldPickupDelay);
+				ie.getScoreboardTags().remove("interactic.ignore_auto_pickup_rule");
 			}
 		}
 	}


### PR DESCRIPTION
Without adding the tag this PR introduces, instant pickup does not work at all if `Auto Pickup` is disabled in Interactic's config. This tag makes Interactic ignore this setting, making it so you can use both - that would resolve gliscowo/interactic#9