### PR TITLE
Fix markdown regexes (#777)

### DIFF
--- a/src/main/java/com/unascribed/fabrication/util/Markdown.java
+++ b/src/main/java/com/unascribed/fabrication/util/Markdown.java
@@ -4,10 +4,10 @@ import java.util.regex.Pattern;
 
 public class Markdown {
 
-	public static final Pattern strike = Pattern.compile("~~(.+)~~");
-	public static final Pattern under = Pattern.compile("~(.+)~");
-	public static final Pattern bold = Pattern.compile("__(.+)__|\\*\\*(.+)\\*\\*");
-	public static final Pattern italic = Pattern.compile("_(.+)_|\\*(.+)\\*");
+	public static final Pattern strike = Pattern.compile("~~(.+?)~~");
+	public static final Pattern under = Pattern.compile("~(.+?)~");
+	public static final Pattern bold = Pattern.compile("__(.+?)__|\\*\\*(.+?)\\*\\*");
+	public static final Pattern italic = Pattern.compile("_(.+?)_|\\*(.+?)\\*");
 	public static final Pattern dedup = Pattern.compile("(§r)+");
 
 	public static String convert(String in){


### PR DESCRIPTION
The capture groups have to be non-greedy to capture multiple formattings of the same type in the same message.

Before: 
![image](https://github.com/user-attachments/assets/f86dcb19-3d0c-4681-8e70-42fd0fc0f023)

After:
![image](https://github.com/user-attachments/assets/8bbb907d-18a1-4fea-b68e-24eaa2491f26)
